### PR TITLE
Add in Overview description & Create Team Contacts page.

### DIFF
--- a/docs/guidelines/overview.md
+++ b/docs/guidelines/overview.md
@@ -1,1 +1,3 @@
-WIP
+This section of the documentation covers user and developer-specific rules.
+
+Be sure to read over this area frequently, as it will be updated to reflect changes voted on by our Developer Compliance and Mod/Admin teams!

--- a/docs/support/team-contacts.md
+++ b/docs/support/team-contacts.md
@@ -1,0 +1,32 @@
+A list of our on-site/Discord teams with relevant situations and contact information. 
+
+If you would like to contact us, please send a site message to the appropriate team below.
+
+## Admins and Moderators
+[Send a Message to RAdmin](https://retroachievements.org/createmessage.php?t=RAdmin) for any User Code of Conduct related issues, such as:
+- Reporting offensive behavior.
+- Reporting copyrighted material.
+- Report cheating to be investigated.
+
+
+## Developer Compliance
+[Send a Message to Developer Compliance](https://retroachievements.org/createmessage.php?t=DevCompliance) for any Developer Code of Conducted related issues, such as:
+- Requesting set approval or early set release.
+- Report achievements or sets with unwelcome concepts.
+- Report sets failing to cover basic progression.
+
+## Quality Assurance
+[Send a Message to Quality Assurance](https://retroachievements.org/createmessage.php?t=QATeam) for:
+* Reporting a broken set, leaderboard, or Rich Presence
+* Reporting achievements with grammar mistakes
+* Rquesting a set playtest or hash compatibility list.
+* Hash or Hub organization questions.
+* Getting involved in a QA sub-team.
+
+## DevQuest
+[Send a Message to DevQuest](https://retroachievements.org/createmessage.php?t=DevQuest) for:
+- DevQuest submissions, questions, ideas, or any DevQuest related issues.
+
+## Quality Quest
+[Send a Message to QualityQuest](https://retroachievements.org/createmessage.php?t=QualityQuest) for:
+* QualityQuest submissions, questions, ideas, or any QualityQuest related issues.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,7 @@ nav:
     - A Message for Achievement Hunters and Completionists About Revisions: 'support/a-message-for-achievement-hunters-and-completionists-about-revisions.md'
     - Reporting Broken Achievements: 'support/reporting-a-broken-achievement.md'
     - Useful Links: 'support/useful-links.md'
-
+    - Team Contacts: 'support/team-contacts.md'
 extra:
   version: '0.0.1'
   font:


### PR DESCRIPTION
- Creates mini overview description for the Guidelines section.
- Creates a Team Contacts page based on Discord RABot's `!contact` command. (Slightly modified for grammar)
- Lists inboxes as hyperlinks.